### PR TITLE
WIP: Add support for bundle-less pages

### DIFF
--- a/layouts/partials/hb/modules/gallery/functions/page-imgs.html
+++ b/layouts/partials/hb/modules/gallery/functions/page-imgs.html
@@ -1,6 +1,12 @@
 {{- $page := . }}
 {{- $imgs := slice }}
 {{- $resources := .Resources.ByType "image" }}
+{{- if not .BundleType }}
+  {{- $parents := .Parent.Resources.ByType "image" }}
+  {{- range .Params.Resources }}
+    {{- $resources = $resources | append (where $parents "Name" .src) }}
+  {{- end }}
+{{- end }}
 {{- range $resources }}
   {{- $img := . }}
   {{- $date := "" }}

--- a/layouts/partials/hb/modules/gallery/functions/sort-imgs.html
+++ b/layouts/partials/hb/modules/gallery/functions/sort-imgs.html
@@ -1,4 +1,8 @@
-{{- $imgs := . }}
-{{- $undatedImgs := sort (where $imgs "Date" nil) "Image.Name" "asc" }}
-{{- $imgs = sort (where $imgs "Date" "ne" nil) "Date" (default "desc" site.Params.hb.gallery.date_sort_order) }}
+{{- $context := .context }}
+{{- $imgs := .images }}
+{{- $undatedImgs := slice }}
+{{- if .PageBundleType }}
+    {{- $undatedImgs = sort (where $imgs "Date" nil) "Image.Name" (default "desc" site.Params.hb.gallery.undated_sort_order) }}
+    {{- $imgs = sort (where $imgs "Date" "ne" nil) "Date" (default "desc" site.Params.hb.gallery.date_sort_order) }}
+{{- end }}
 {{- return ($imgs | append $undatedImgs) }}

--- a/layouts/partials/hb/modules/gallery/functions/sorted-page-imgs.html
+++ b/layouts/partials/hb/modules/gallery/functions/sorted-page-imgs.html
@@ -1,2 +1,2 @@
 {{- $imgs := partialCached "hb/modules/gallery/functions/page-imgs" . . }}
-{{- return (partial "hb/modules/gallery/functions/sort-imgs" $imgs) }}
+{{- return (partial "hb/modules/gallery/functions/sort-imgs" (dict "context" . "images" $imgs)) }}


### PR DESCRIPTION
Situation -- we have a common pool of images in a branch bundle, and we want to produce subsets of those images as sub-galleries. Normally we would have to duplicate images in content/gallery/branch/leaf1 and content/gallery/branch/leaf2. Instead, allow support for bundleless pages under gallery.
```
gallery
| -- branch
| ---- _index.md
| ---- **.jpg
| ---- subset1.md
| ---- subset2.md
```

Images in subset1.md must appear in subset1's frontmatter resources page.

Has not been thoroughly tested with globs!
Submitting pull request for your thoughts and opinions.

Oh, other thing of note, sorting is disabled for bundle-less pages since the sort order can manually be defined by the resources slice.