### PR TITLE
style: list galleries with the hierarchy

### DIFF
--- a/layouts/gallery/list.html
+++ b/layouts/gallery/list.html
@@ -1,5 +1,5 @@
 {{- define "title" }}
-  {{- $pages := .RegularPagesRecursive }}
+  {{- $pages := .Pages }}
   {{- $paginator := .Paginate $pages .Site.Params.hb.gallery.paginate }}
   {{ partial "base/title" . }}
 {{- end -}}

--- a/layouts/partials/hb/modules/gallery/list.html
+++ b/layouts/partials/hb/modules/gallery/list.html
@@ -6,7 +6,14 @@
       class="hb-gallery-album hb-gallery-album-items d-flex flex-wrap hb-module">
       {{- range .Paginator.Pages }}
         {{- $page := . }}
-        {{- $imgs := partial "hb/modules/gallery/functions/sorted-page-imgs" . }}
+        {{- $imgs := slice }}
+        {{- if $page.IsSection }}
+          {{- range $page.RegularPages }}
+            {{- $imgs = $imgs | append (partial "hb/modules/gallery/functions/sorted-page-imgs" .) }}
+          {{- end }}
+        {{- else }}
+          {{- $imgs = partial "hb/modules/gallery/functions/sorted-page-imgs" . }}
+        {{- end }}
         {{- with index $imgs 0 }}
           <a
             class="hb-gallery-album-item flex-grow-1 position-relative"


### PR DESCRIPTION
```sh
$ tree content/gallery
├── _index.md
├── dogs
│   ├── index.md
├── events
│   ├── _index.md
│   ├── bar
│   │   ├── 11-tests.jpg
│   │   ├── index.md
│   └── foo
│       ├── index.md
│       └── jolla.jpg
├── exif
│   ├── 1.jpg
│   └── index.md
├── rainbow
│   ├── 20220101-featured.jpg
│   ├── index.md
├── sunrise
│   ├── index.md
└── textures
    ├── index.md
```

As the structure above shown, there is an `events` sub gallery that contains two albums (`foo` and `bar`), with this PR:

`/gallery` list as follows.

![image](https://github.com/hbstack/gallery/assets/17720932/c8c900ac-95aa-488c-a7b3-42e4d8cb4d5d)

When clicking the _Events_, then open `/gallery/events`.

![image](https://github.com/hbstack/gallery/assets/17720932/1cb03447-58d7-4abf-81a6-45db488a8be1)


