### PR TITLE
WIP: Add support for gallery highlight images

### DIFF
--- a/layouts/partials/hb/modules/gallery/functions/page-imgs.html
+++ b/layouts/partials/hb/modules/gallery/functions/page-imgs.html
@@ -1,6 +1,11 @@
+{{- $arguments := dict }}
 {{- $page := . }}
+{{- if (reflect.IsMap .) }}
+  {{- $arguments = .arguments }}
+  {{- $page = .context }}
+{{- end }}
 {{- $imgs := slice }}
-{{- $resources := .Resources.ByType "image" }}
+{{- $resources := $page.Resources.ByType "image" }}
 {{- range $resources }}
   {{- $img := . }}
   {{- $date := "" }}
@@ -12,10 +17,20 @@
       {{- $date = time.AsTime . }}
     {{- end }}
   {{- end }}
-  {{- with $date }}
-    {{- $imgs = $imgs | append (dict "Image" $img "Page" $page "Date" $date) }}
-  {{- else }}
-    {{- $imgs = $imgs | append (dict "Image" $img "Page" $page) }}
+  {{- if (or $img.Params.highlight (not $arguments.highlights_only)) }}
+      {{- with $date }}
+        {{- $imgs = $imgs | append (dict "Image" $img "Page" $page "Date" $date) }}
+      {{- else }}
+        {{- $imgs = $imgs | append (dict "Image" $img "Page" $page) }}
+      {{- end }}
   {{- end }}
 {{- end }}
+{{- $highlight_imgs := slice }}
+{{- if $page.IsSection }}
+    {{- range $page.RegularPages.ByTitle -}}
+        {{- $highlights := (partial "hb/modules/gallery/functions/page-imgs.html" (dict "context" . "arguments" (dict "highlights_only" true))) }}
+        {{- $highlight_imgs = $highlight_imgs | append $highlights }}
+    {{- end }}
+{{- end }}
+{{- $imgs = $highlight_imgs | append $imgs }}
 {{- return $imgs }}

--- a/layouts/partials/hb/modules/gallery/list.html
+++ b/layouts/partials/hb/modules/gallery/list.html
@@ -4,6 +4,18 @@
   <div class="hb-gallery-albums">
     <div
       class="hb-gallery-album hb-gallery-album-items d-flex flex-wrap hb-module">
+      {{- $highlights := partial "hb/modules/gallery/functions/sorted-page-imgs" . }}
+      {{- warnf "page: %v highlights: %v" . $highlights }}
+      {{- range $highlights }}
+        <div class="hb-gallery-album-item flex-grow-1 position-relative">
+          {{- partialCached "hb/modules/gallery/img" .Image .Image }}
+          {{- partialCached "hb/modules/gallery/info" .Image .Image }}
+          <p
+            class="hb-gallery-title position-absolute bottom-0 mb-0 px-1 text-white text-center w-100 text-truncate">
+            {{- default .Image.Name .Image.Title -}}
+          </p>
+        </div>
+      {{- end }}
       {{- range .Paginator.Pages }}
         {{- $page := . }}
         {{- $imgs := slice }}

--- a/layouts/partials/hb/modules/gallery/list.html
+++ b/layouts/partials/hb/modules/gallery/list.html
@@ -5,7 +5,6 @@
     <div
       class="hb-gallery-album hb-gallery-album-items d-flex flex-wrap hb-module">
       {{- $highlights := partial "hb/modules/gallery/functions/sorted-page-imgs" . }}
-      {{- warnf "page: %v highlights: %v" . $highlights }}
       {{- range $highlights }}
         <div class="hb-gallery-album-item flex-grow-1 position-relative">
           {{- partialCached "hb/modules/gallery/img" .Image .Image }}


### PR DESCRIPTION
If you have a section/branch page in the gallery, and there is a child page that has images marked as highlight images, display those image in the list page as well. This is used to create a "best of" top level gallery, followed by the standard gallery page links.

Uses .Image.Params.Highlight = True to determine if an image should appear in the parent's page.

With the example hierarchy:
```
content/gallery
├── 2023-presidents-day
│   ├── _index.md
│   ├── day1
│   │   ├── 441A8531.jpg
│   │   ├── 441A8533.jpg
│   │   ├── 441A8572-featured.jpg
│   │   ├── 441A8712.jpg
│   │   ├── 441A8877.jpg
│   │   ├── 441A8879.jpg
│   │   ├── 441A8889.jpg
│   │   ├── 441A9174.jpg
│   │   ├── index.md
│   │   ├── map_sat.webp
│   ├── day2
│   │   ├── IMG_2194.jpg
│   │   ├── IMG_2199.jpg
│   │   ├── IMG_2960.jpg
│   │   ├── index.md
│   │   ├── map_sun.webp
│   └── day3
│   │   ├── IMG_2294.jpg
│   │   ├── IMG_2299.jpg
│   │   ├── IMG_2060.jpg
│   │   ├── index.md
│   │   └── map_mon.webp
└── _index.en.md
```

day1/index.md:
```
resources:
  - src: map_sat.webp
    name: " Day 1 Route Map"
    title: Day 1 Route Map
    params:
      author: Ich
      highlight: true
```

day2/index.md:
```
resources:
  - src: map_sun.webp
    name: " Day 2 Route Map"
    title: Day 2 Route Map
    params:
      author: Ich
      highlight: true
  - src: IMG_2961p.jpg
    title: Bull Canyon Rd bridge over the Santa Maria River
```

Would display 2 highlight images (Day 1 Route Map and Day 2 Route Map) on the gallery/2023-presidents-day/ page followed by the 3 child galleries.