### PR TITLE
feat: allow highlighting the images and display them in parent section

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -18,3 +18,4 @@ paginate = 24
 # - x[height]: resize to a height of [height]px and preserve aspect ratio, such as x640.
 thumbnail_size = "x640"
 date_sort_order = "desc"
+highlight_images_count = 10

--- a/layouts/partials/hb/modules/gallery/highlight.html
+++ b/layouts/partials/hb/modules/gallery/highlight.html
@@ -1,0 +1,18 @@
+{{- if .IsSection }}
+  {{- $imgs := slice }}
+  {{- range .RegularPages }}
+    {{- $imgs = $imgs | append (partialCached "hb/modules/gallery/functions/page-imgs" . .) }}
+  {{- end }}
+  {{- $imgs = where $imgs ".Image.Params.highlight" true }}
+  {{- $imgs = partial "hb/modules/gallery/functions/sort-imgs" $imgs }}
+  {{- range first (default 10 site.Params.hb.gallery.highlight_images_count) $imgs }}
+    <div class="hb-gallery-album-item hb-gallery-album-item-highlight flex-grow-1 position-relative">
+      {{- partialCached "hb/modules/gallery/img" .Image .Image }}
+      {{- partialCached "hb/modules/gallery/info" .Image .Image }}
+      <p
+        class="hb-gallery-title position-absolute bottom-0 mb-0 px-1 text-white text-center w-100 text-truncate">
+        {{- default .Image.Name .Image.Title -}}
+      </p>
+    </div>
+  {{- end }}
+{{- end }}

--- a/layouts/partials/hb/modules/gallery/list.html
+++ b/layouts/partials/hb/modules/gallery/list.html
@@ -4,6 +4,7 @@
   <div class="hb-gallery-albums">
     <div
       class="hb-gallery-album hb-gallery-album-items d-flex flex-wrap hb-module">
+      {{- partial "hb/modules/gallery/highlight" . }}
       {{- range .Paginator.Pages }}
         {{- $page := . }}
         {{- $imgs := slice }}


### PR DESCRIPTION
Closes #96

To highlight an image.

```
// content/gallery/foo/index.md
resources:
  - src: foo.jpg
    params:
      highlight: true
```

To limit the number of highlighting images.

```
// params.yaml
hb:
  gallery:
    highlight_images_count: 10
```